### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   },
   "require": {
     "php": ">=7.0.0",
-    "laravel/framework": "^5.0.0"
+    "laravel/framework": "5.0.* || 5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.*"
   },
   "repositories": [{
     "type": "git",


### PR DESCRIPTION
Laravel doesn't follow semver. So having `^5.x`, `5.*` or `>=5.x` will mean that composer will install a future version even though that version breaks the package.