### PR TITLE
Require any version of Laravel from 5.x through 8.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   },
   "require": {
     "php": ">=7.0.0",
-    "laravel/framework": "5.0.* || 5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.*"
+    "laravel/framework": "^5.0 || ^6.0 || ^7.0 || ^8.0"
   },
   "repositories": [{
     "type": "git",


### PR DESCRIPTION
Hi there! Thanks for this handy package. I found it while trying to figure out how to do these more complex sorts of relations and discovered that it still works as-is with the Laravel 8.x branch! This PR simply updates the framework version required by the package to match any version from the 5, 6, 7, or 8 major release branches.